### PR TITLE
fix: set the `cmake` file type using `overrides`.

### DIFF
--- a/cmake/cspell-ext.json
+++ b/cmake/cspell-ext.json
@@ -18,5 +18,6 @@
       "dictionaries": ["cmake"],
       "dictionaryDefinitions": []
     }
-  ]
+  ],
+  "overrides": [{ "filename": ["**/*.cmake", "**/CMakeLists.txt"], "languageId": "cmake" }]
 }


### PR DESCRIPTION
Related to: https://github.com/streetsidesoftware/cspell/pull/3560#issuecomment-1243240102

Even though `cspell` 6.8.2 will support `cmake` file types, it is better to be explicit in the `cspell-ext.json` file to support older versions of `cspell`.