### PR TITLE
feat(caret/words): add TILDE

### DIFF
--- a/caret/words.txt
+++ b/caret/words.txt
@@ -10,6 +10,7 @@ minc
 Passingvalue
 Recordsinterface
 Summarizable
+TILDE
 Timeseries
 tracepoint
 tracepoints


### PR DESCRIPTION
Signed-off-by: keita1523 <keita.miura@tier4.jp>

TILDE is described in CARET_analyze.
https://github.com/keita1523/CARET_analyze/blob/81af77e543cd2f2deee0f40c45a6425e9db9036f/src/caret_analyze/infra/lttng/records_provider_lttng.py#L1301

Spell check errors occurred in following PR.
https://github.com/tier4/CARET_analyze/pull/204