### PR TITLE
feat(caret/words): add pydantic

### DIFF
--- a/caret/words.txt
+++ b/caret/words.txt
@@ -9,6 +9,7 @@ Hashable
 lsplit
 minc
 Passingvalue
+pydantic
 Recordsinterface
 Summarizable
 TILDE


### PR DESCRIPTION
[pydantic](https://pydantic-docs.helpmanual.io/) is name of commonly used data validation for Python.
CARET started using pydantic in [the PR](https://github.com/tier4/CARET_analyze/pull/186/files), but it cause an error from cspell checking.

Signed-off-by: Takayuki AKAMINE <takayuki.akamine@tier4.jp>