### PR TITLE
feat(caret/words): add logger config keyword

### DIFF
--- a/caret/words.txt
+++ b/caret/words.txt
@@ -1,8 +1,10 @@
 # cspell-tools: keep-case no-split
+asctime
 Azumi
 babeltrace
 binsize
 cpuid
+datefmt
 dataframe
 fini
 Hashable


### PR DESCRIPTION
In CARET, log output can be configured from a configuration file (features added by the [PR](https://github.com/tier4/CARET_analyze/pull/220)), but it cause an error from cspell checking.

Signed-off-by: yamasaki <114902604+ymski@users.noreply.github.com>