### PR TITLE
feat(caret/words): add libtracetools

### DIFF
--- a/caret/words.txt
+++ b/caret/words.txt
@@ -24,6 +24,7 @@ NEDO
 sched
 DBUILD
 libcaret
+libtracetools
 LSTRIP
 RSTRIP
 YYYYMMDD


### PR DESCRIPTION
libtracetools is the file name of ROS 2 trace tool library stored in `/opt/ros/humble/lib/libtracetools.so`

Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>