### PR TITLE
feat(caret/words): add pandas function "isin"

### DIFF
--- a/caret/words.txt
+++ b/caret/words.txt
@@ -15,6 +15,7 @@ Hasegawa
 Hashable
 HHMMSS
 ICESS
+isin
 Kato
 Kuboichi
 libcaret


### PR DESCRIPTION
`isin`, a function of pandas, caused spelling error on CARET's Github Actions.

To improve this, I added `isin` to the dictionary.
- `isin`: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.isin.html