### PR TITLE
ci: add a workflow to add a word

### DIFF
--- a/.github/workflows/add-word.yaml
+++ b/.github/workflows/add-word.yaml
@@ -1,0 +1,62 @@
+name: add-word
+
+on:
+  workflow_dispatch:
+    inputs:
+      dictionary:
+        description: The target dictionary
+        required: true
+        type: string
+      word:
+        description: A word
+        required: true
+        type: string
+
+jobs:
+  add-word:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up sd
+        uses: kenji-miyake/setup-sd@v1
+      - name: Update .cspell.json
+        run: |
+          sd '\z' '${{ inputs.word }}' ${{ inputs.dictionary }}/words.txt
+
+      - name: Create PR
+        id: create-pr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          base: ${{ github.event.repository.default_branch }}
+          branch: add-word-${{ inputs.word }}
+          title: "feat(words): add ${{ inputs.word }}"
+          commit-message: "feat(words): add ${{ inputs.word }}"
+          body: "TODO: Update this comment and add some reference links."
+          labels: |
+            bot
+            add-word
+          signoff: true
+          delete-branch: true
+
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.create-pr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.create-pr.outputs.pull-request-url }}"
+
+      - name: Enable auto-merge
+        if: ${{ steps.create-pr.outputs.pull-request-operation == 'created' }}
+        uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+          merge-method: squash


### PR DESCRIPTION
To make the word-adding process easier.
Modified from https://github.com/tier4/autoware-spell-check-dict/blob/main/.github/workflows/add-word.yaml.