### PR TITLE
feat(caret/words): add words used in Cyclone DDS

### DIFF
--- a/caret/words.txt
+++ b/caret/words.txt
@@ -9,6 +9,7 @@ cpuid
 dataframe
 datefmt
 DBUILD
+ddsc
 EPNS
 eprosima
 fastcdr


### PR DESCRIPTION
- New words
  - `ddsc` is the name of Cyclone DDS module

- Related links:
  - https://github.com/tier4/caret/pull/121.