### PR TITLE
feat(caret/words): add sessiond for lttng-sessiond process

### DIFF
--- a/caret/words.txt
+++ b/caret/words.txt
@@ -40,6 +40,7 @@ Recordsinterface
 ROSCON
 RSTRIP
 sched
+sessiond
 setenv
 simtime
 Summarizable


### PR DESCRIPTION
- New words
  - `sessiond` used in lttng-sessiond process.
- Related links:
  - https://github.com/tier4/caret/pull/142