### PR TITLE
feat(caret/words): add subbuffer

### DIFF
--- a/caret/words.txt
+++ b/caret/words.txt
@@ -40,6 +40,8 @@ RSTRIP
 sched
 setenv
 simtime
+subbuffer
+subbuffers
 Summarizable
 TILDE
 Timeseries


### PR DESCRIPTION
`subbuffer`: is used in [ros2_tracing](https://github.com/ros2/ros2_tracing/blob/0041e07e034538f7fa99cdcbe7c2d2c83dc1d272/tracetools_trace/tracetools_trace/tools/lttng_impl.py#L150)
Related PR link:  https://github.com/tier4/ros2caret/pull/85