### PR TITLE
feat(caret/words): add `autorefs`

### DIFF
--- a/caret/words.txt
+++ b/caret/words.txt
@@ -1,6 +1,7 @@
 # cspell-tools: keep-case no-split
 
 asctime
+autorefs
 Azumi
 babeltrace
 binsize


### PR DESCRIPTION
- `autorefs` is plugin used with mkdocs. https://github.com/tier4/caret_analyze/blob/main/mkdocs.yaml#L60
