### PR TITLE
feat(caret/words): add words used in ros2 caret

### DIFF
--- a/caret/words.txt
+++ b/caret/words.txt
@@ -18,12 +18,15 @@ FASTDDS
 fastdds
 fini
 Funaoka
+genexp
 groupby
 Hasegawa
 Hashable
 HHMMSS
 ICESS
+includecache
 ipbs
+ipynb
 isin
 Kato
 Kuboichi
@@ -37,6 +40,7 @@ mininterval
 Miura
 NEDO
 Passingvalue
+polygraphy
 pydantic
 Recordsinterface
 ROSCON


### PR DESCRIPTION
genexp: GenExpr is identified as the internal language utilized by gen patchers. https://docs.cycling74.com/max8/vignettes/gen_genexpr

polygraphy: a toolkit designed to assist in running and debugging deep learning models in various frameworks. https://github.com/NVIDIA/TensorRT/tree/main/tools/Polygraphy

ipynb : The .ipynb file extension stands for IPython Notebook, which is a format used by Jupyter Notebook. https://ipynb.readthedocs.io/en/stable/#

includecache: In the build folder of a CMake project, includecache refers to a file named C.includecache generated by CMake. The file contains the include dependency information​​.

Related PR Link:  https://github.com/tier4/ros2caret/pull/129/files