### PR TITLE
feat(caret/words): add openadk

### DIFF
--- a/caret/words.txt
+++ b/caret/words.txt
@@ -40,6 +40,7 @@ minc
 mininterval
 Miura
 NEDO
+openadk
 Passingvalue
 polygraphy
 pydantic


### PR DESCRIPTION
`openadk`: Partial name of docker image used in pytest job.

Related PRs:
- https://github.com/tier4/caret_analyze/pull/483
- https://github.com/tier4/ros2caret/pull/178