### PR TITLE
revert(caret/words): "remove nproc"

### DIFF
--- a/caret/words.txt
+++ b/caret/words.txt
@@ -41,7 +41,6 @@ minc
 mininterval
 Miura
 NEDO
-nproc
 openadk
 Passingvalue
 polygraphy


### PR DESCRIPTION
Reverts tier4/cspell-dicts#94
`nproc` has been added in the following
https://github.com/tier4/autoware-spell-check-dict/pull/739 