### PR TITLE
revert(caret/words): remove libpcre

### DIFF
--- a/caret/words.txt
+++ b/caret/words.txt
@@ -31,7 +31,6 @@ isin
 Kato
 Kuboichi
 libcaret
-libpcre
 libraryv
 libtracetools
 lsplit


### PR DESCRIPTION
Reverts #93
`libpcre` has already been added in the following PR
https://github.com/tier4/autoware-spell-check-dict/pull/740